### PR TITLE
Adds batch set/delete operations to Properties and a static Create function for Environment

### DIFF
--- a/lib/Environment.js
+++ b/lib/Environment.js
@@ -10,8 +10,23 @@ function Environment () {
 		return name.toUpperCase();
 	}
 
+	function normalizeNames (names) {
+		return _.map(names, normalizeName);
+	}
+
+	function normalizeKeyNames (values) {
+		return _.transform(values, function (result, val, key) {
+			result[normalizeName(key)] = val;
+			return result;
+		});
+	}
+
 	this.delete = function (name) {
 		return properties.delete.call(this, normalizeName(name));
+	};
+
+	this.deleteAll = function (names) {
+		return properties.deleteAll.call(this, normalizeNames(names));
 	};
 
 	this.get = function (name) {
@@ -21,8 +36,21 @@ function Environment () {
 	this.set = function (name, value) {
 		return properties.set.call(this, normalizeName(name), value);
 	};
+
+	this.setAll = function (values) {
+		return properties.setAll.call(this, normalizeKeyNames(values));
+	};
 }
 
 Environment.prototype = Object.create(Properties.prototype);
+
+Environment.create = function (newEnvironment) {
+	var environment = new Environment();
+	environment.deleteAll(_.keys(process.env));
+	environment.setAll(newEnvironment);
+	return environment;
+};
+
+Object.freeze(Environment);
 
 module.exports = Environment;

--- a/lib/Properties.js
+++ b/lib/Properties.js
@@ -38,13 +38,15 @@ function Properties (subject) {
 	};
 
 	this.deleteAll = function (names) {
-		var self = this;
 		var restores = _.map(names, function (name) {
-			self.set(name);
+			return set(name);
 		});
-		return function () {
+
+		var restore = function () {
 			return restoreAll(restores);
 		};
+		changes.push(restore);
+		return restore;
 	};
 
 	this.get = function (name) {
@@ -61,17 +63,18 @@ function Properties (subject) {
 	};
 
 	this.setAll = function (sets) {
-		var self = this;
 		var restores = _.map(
 			sets,
 			function (value, key) {
-				return self.set(key, value);
+				return set(key, value);
 			}
 		);
 
-		return function () {
+		var restore = function () {
 			return restoreAll(restores);
 		};
+		changes.push(restore);
+		return restore;
 	};
 
 	this.restore = function () {

--- a/lib/Properties.js
+++ b/lib/Properties.js
@@ -1,4 +1,5 @@
 "use strict";
+var _ = require("lodash");
 
 function Properties (subject) {
 	var changes = [];
@@ -20,8 +21,30 @@ function Properties (subject) {
 		return set.bind(null, name, previousValue);
 	}
 
+	function restoreAll (changeSet) {
+		var restore = changeSet.pop();
+		var revertChangeSet = [];
+
+		while (restore) {
+			revertChangeSet.push(restore());
+			restore = changeSet.pop();
+		}
+
+		return restoreAll.bind(null, revertChangeSet);
+	}
+
 	this.delete = function (name) {
 		return this.set(name);
+	};
+
+	this.deleteAll = function (names) {
+		var self = this;
+		var restores = _.map(names, function (name) {
+			self.set(name);
+		});
+		return function () {
+			return restoreAll(restores);
+		};
 	};
 
 	this.get = function (name) {
@@ -37,13 +60,22 @@ function Properties (subject) {
 		return restore;
 	};
 
-	this.restore = function () {
-		var restore = changes.pop();
+	this.setAll = function (sets) {
+		var self = this;
+		var restores = _.map(
+			sets,
+			function (value, key) {
+				return self.set(key, value);
+			}
+		);
 
-		while (restore) {
-			restore();
-			restore = changes.pop();
-		}
+		return function () {
+			return restoreAll(restores);
+		};
+	};
+
+	this.restore = function () {
+		restoreAll(changes);
 	};
 }
 

--- a/test/Environment_spec.js
+++ b/test/Environment_spec.js
@@ -4,6 +4,7 @@ var Environment = require("../lib/Environment");
 var Properties  = require("../lib/Properties");
 var Lab         = require("lab");
 var script      = exports.lab = Lab.script();
+var _           = require("lodash");
 
 var before   = script.before;
 var after    = script.after;
@@ -32,6 +33,16 @@ describe("an Environment", function () {
 		done();
 	});
 
+	it("has a static create function", function (done) {
+		expect(Environment.create, "no create function").to.be.a("function");
+		done();
+	});
+
+	it("has constant static properties", function (done) {
+		expect(Object.isFrozen(Environment), "frozen").to.be.true;
+		done();
+	});
+
 	describe("deleting a property", function () {
 		var name  = "test";
 		var value = "super-awesome-test-value";
@@ -54,6 +65,35 @@ describe("an Environment", function () {
 		});
 	});
 
+	describe("deleting multiple properties", function () {
+		var names = [ "foo", "bar" ];
+		var value = "super-awesome-test-value";
+
+		before(function (done) {
+			names.forEach(function (name) {
+				process.env[name.toUpperCase()] = value;
+			});
+
+			environment.deleteAll(names);
+			done();
+		});
+
+		after(function (done) {
+			environment.restore();
+			names.forEach(function (name) {
+				delete process.env[name.toUpperCase()];
+			});
+			done();
+		});
+
+		it("deletes the properties", function (done) {
+			names.forEach(function (name) {
+				expect(process.env[name.toUpperCase()]).to.be.undefined;
+			});
+			done();
+		});
+	});
+
 	describe("setting a property", function () {
 		var name  = "test";
 		var value = "super-awesome-test-value";
@@ -68,8 +108,32 @@ describe("an Environment", function () {
 			done();
 		});
 
-		it("deletes the property", function (done) {
+		it("sets the property", function (done) {
 			expect(process.env[name.toUpperCase()]).to.equal(value);
+			done();
+		});
+	});
+
+	describe("setting multiple properties", function () {
+		var values = {
+			foo : "foo",
+			bar : "bar"
+		};
+
+		before(function (done) {
+			environment.setAll(values);
+			done();
+		});
+
+		after(function (done) {
+			environment.restore();
+			done();
+		});
+
+		it("sets the properties", function (done) {
+			_.forEach(values, function (value, key) {
+				expect(process.env[key.toUpperCase()]).to.equal(value);
+			});
 			done();
 		});
 	});
@@ -92,6 +156,40 @@ describe("an Environment", function () {
 
 		it("deletes the property", function (done) {
 			expect(process.env[name.toUpperCase()]).to.equal(value);
+			done();
+		});
+	});
+
+	describe("creating an environment from a hash", function () {
+		var values = {
+			foo : "foo",
+			bar : "bar"
+		};
+
+		var environment;
+
+		before(function (done) {
+			process.env.BAZ = "unwanted value";
+			process.env.FOO = "overwritten value";
+
+			environment = Environment.create(values);
+			done();
+		});
+
+		after(function (done) {
+			environment.restore();
+			done();
+		});
+
+		it("sets the provided properties", function (done) {
+			_.forEach(values, function (value, key) {
+				expect(process.env[key.toUpperCase()]).to.equal(value);
+			});
+			done();
+		});
+
+		it("unsets extra properties", function (done) {
+			expect(process.env.BAZ, "extra value").to.be.undefined;
 			done();
 		});
 	});

--- a/test/Environment_spec.js
+++ b/test/Environment_spec.js
@@ -34,12 +34,12 @@ describe("an Environment", function () {
 	});
 
 	it("has a static create function", function (done) {
-		expect(Environment.create, "no create function").to.be.a("function");
+		expect(Environment.create, "no create function").to.be.a.function();
 		done();
 	});
 
 	it("has constant static properties", function (done) {
-		expect(Object.isFrozen(Environment), "frozen").to.be.true;
+		expect(Object.isFrozen(Environment), "frozen").to.be.true();
 		done();
 	});
 
@@ -60,7 +60,7 @@ describe("an Environment", function () {
 		});
 
 		it("deletes the property", function (done) {
-			expect(process.env[name]).to.be.undefined;
+			expect(process.env[name]).to.be.undefined();
 			done();
 		});
 	});
@@ -88,7 +88,7 @@ describe("an Environment", function () {
 
 		it("deletes the properties", function (done) {
 			names.forEach(function (name) {
-				expect(process.env[name.toUpperCase()]).to.be.undefined;
+				expect(process.env[name.toUpperCase()]).to.be.undefined();
 			});
 			done();
 		});
@@ -189,7 +189,7 @@ describe("an Environment", function () {
 		});
 
 		it("unsets extra properties", function (done) {
-			expect(process.env.BAZ, "extra value").to.be.undefined;
+			expect(process.env.BAZ, "extra value").to.be.undefined();
 			done();
 		});
 	});

--- a/test/Properties_spec.js
+++ b/test/Properties_spec.js
@@ -36,7 +36,7 @@ describe("Properties", function () {
 
 		it("sets the values", function (done) {
 			_.forEach(context.names, function (key) {
-				expect(context.properties.get(key), "value of " + key).to.be.undefined;
+				expect(context.properties.get(key), "value of " + key).to.be.undefined();
 			});
 			done();
 		});
@@ -74,7 +74,7 @@ describe("Properties", function () {
 
 	function describeRestoreAllFunction (context, isDeleteOperation) {
 		it("returns a 'restoreAll' function", function (done) {
-			expect(context.result, "type").to.be.a("function");
+			expect(context.result, "type").to.be.a.function();
 			done();
 		});
 
@@ -99,7 +99,7 @@ describe("Properties", function () {
 
 	function describeRestoreAllRevertFunction (context, isDeleteOperation) {
 		it("returns a revert function after restoring", function (done) {
-			expect(context.revert, "type").to.be.a("function");
+			expect(context.revert, "type").to.be.a.function();
 			done();
 		});
 
@@ -112,7 +112,7 @@ describe("Properties", function () {
 			if (isDeleteOperation) {
 				it("redoes multiple delete operations", function (done) {
 					_.forEach(context.names, function (name) {
-						expect(context.properties.get(name), "value of " + name).to.be.undefined;
+						expect(context.properties.get(name), "value of " + name).to.be.undefined();
 					});
 
 					done();
@@ -398,7 +398,7 @@ describe("Properties", function () {
 		});
 
 		it("reverts all changes to the properties", function (done) {
-			expect(properties.get("bar"), "bar").to.be.undefined;
+			expect(properties.get("bar"), "bar").to.be.undefined();
 			done();
 		});
 	});
@@ -417,8 +417,8 @@ describe("Properties", function () {
 		});
 
 		it("reverts all changes to the properties", function (done) {
-			expect(properties.get("multiA"), "multiA").to.be.undefined;
-			expect(properties.get("multiB"), "multiB").to.be.undefined;
+			expect(properties.get("multiA"), "multiA").to.be.undefined();
+			expect(properties.get("multiB"), "multiB").to.be.undefined();
 			done();
 		});
 	});

--- a/test/Properties_spec.js
+++ b/test/Properties_spec.js
@@ -385,4 +385,61 @@ describe("Properties", function () {
 			done();
 		});
 	});
+
+	describe("restoring all changes after calling an individual restore function", function () {
+		var bar = "bar";
+		var properties = new Properties({});
+
+		before(function (done) {
+			var individualRestore = properties.set("bar", bar);
+			individualRestore();
+			properties.restore();
+			done();
+		});
+
+		it("reverts all changes to the properties", function (done) {
+			expect(properties.get("bar"), "bar").to.be.undefined;
+			done();
+		});
+	});
+
+	describe("restoring all changes after calling a batch set restore function", function () {
+		var multiA = "a";
+		var multiB = "b";
+
+		var properties = new Properties({});
+
+		before(function (done) {
+			var batchRestore = properties.setAll({ multiA : multiA, multiB : multiB });
+			batchRestore();
+			properties.restore();
+			done();
+		});
+
+		it("reverts all changes to the properties", function (done) {
+			expect(properties.get("multiA"), "multiA").to.be.undefined;
+			expect(properties.get("multiB"), "multiB").to.be.undefined;
+			done();
+		});
+	});
+
+	describe("restoring all changes after calling a batch delete function", function () {
+		var multiA = "a";
+		var multiB = "b";
+
+		var properties = new Properties({ multiA : "a", multiB : "b" });
+
+		before(function (done) {
+			var batchRestore = properties.deleteAll([ "multiA", "multiB" ]);
+			batchRestore();
+			properties.restore();
+			done();
+		});
+
+		it("reverts all changes to the properties", function (done) {
+			expect(properties.get("multiA"), "multiA").to.equal(multiA);
+			expect(properties.get("multiB"), "multiB").to.equal(multiB);
+			done();
+		});
+	});
 });


### PR DESCRIPTION
The implementation may not be 100% intuitive, nor 100% elegant, which is unfortunate. Here are some design decisions which need an opinion:

* `setAll` / `deleteAll` return a batch `restore` function; i.e. calling the `restore` function will undo all modifications from `setAll` or `deleteAll`. Batch `restore`s are also pushed on the internal `change` stack.

* `Environment.create` does a batch delete of keys in `process.env` before continuing, which feels a little odd to me, but then again, I don't see another way to clear the environment.

Another note on the existing codebase: should the `"restoring multiple single-value changes"` test in `Properties_spec.js` (line `308` in my branch) include `foo` in the initial Properties constructor hash to really test deletion restoration?

I took the liberty of adding some test coverage for cases that interested me and didn't seem covered: calling an individually created `restore` function from a set/delete operation and then proceeding to call the full `restore` on the `Properties` instance.